### PR TITLE
Rename startKey() into setStartKey() to be consistent with the naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,11 +324,11 @@ Demand that items be returned in ascending ASCII or numerical value. This is the
 
 Demand that items be returned in descending ASCII or numerical value.
 
-#### startKey(key)
+#### setStartKey(key)
 
 Start the query at a specified hash key. Useful when your request is returned in chunks and subsequent chunks need to be retrieved after the current batch is processed.
 
-When partial results are returned, the `LastEvaluatedKey` can be passed in as an argument to `startKey()` on the next query to get the next section of results.
+When partial results are returned, the `LastEvaluatedKey` can be passed in as an argument to `setStartKey()` on the next query to get the next section of results.
 
 #### setLimit(max)
 
@@ -394,7 +394,7 @@ A simple scan looks like this:
             // data.result contains all of the users
         })
 
-If your dataset contains more than 1 MB of data, the `data` that is returned will contain a `LastEvaluatedKey` key that will tell you what the last evaluated key for the scan was, so you can start the next `scan` there by passing the `LastEvaluatedKey` to `startKey(key)`.
+If your dataset contains more than 1 MB of data, the `data` that is returned will contain a `LastEvaluatedKey` key that will tell you what the last evaluated key for the scan was, so you can start the next `scan` there by passing the `LastEvaluatedKey` to `setStartKey(key)`.
 
 #### .filterAttributeEquals(field, value)
 

--- a/lib/QueryBuilder.js
+++ b/lib/QueryBuilder.js
@@ -87,7 +87,7 @@ QueryBuilder.prototype.indexBetween = function (name, val1, val2) {
   return this
 }
 
-QueryBuilder.prototype.startKey = function (key) {
+QueryBuilder.prototype.setStartKey = function (key) {
   this._startKey = key
   return this
 }

--- a/lib/ScanBuilder.js
+++ b/lib/ScanBuilder.js
@@ -99,7 +99,7 @@ ScanBuilder.prototype.filterAttributeIn = function (key, vals) {
   return this
 }
 
-ScanBuilder.prototype.startKey = function (key) {
+ScanBuilder.prototype.setStartKey = function (key) {
   this._startKey = key
   return this
 }

--- a/test/testQuery.js
+++ b/test/testQuery.js
@@ -165,7 +165,7 @@ builder.add(function testCursorForward(test) {
       return client.newQueryBuilder('comments')
         .setHashKey('postId', 'post1')
         .indexBetween('column', '/comment/', '/comment/timestamp/999999')
-        .startKey(data.LastEvaluatedKey)
+        .setStartKey(data.LastEvaluatedKey)
         .execute()
     })
     .then(function (data) {
@@ -189,7 +189,7 @@ builder.add(function testCursorBackward(test) {
         .setHashKey('postId', 'post1')
         .indexBetween('column', '/comment/', '/comment/timestamp/999999')
         .scanBackward()
-        .startKey(data.LastEvaluatedKey)
+        .setStartKey(data.LastEvaluatedKey)
         .execute()
     })
     .then(function (data) {


### PR DESCRIPTION
Hello @dpup, 

Please review the following commits I made in branch 'xiao-setStartKey'.

e686fffe35cacb68e9c9a6d0718498d9658eb188 (2013-10-14 16:36:42 -0700)
Rename startKey() into setStartKey() to be consistent with the naming convention

Check list:

R=@dpup
