### PR TITLE
Revert "Fixed unit test testDeleteAllItemsFromStringSet"

### DIFF
--- a/test/testUpdateItem.js
+++ b/test/testUpdateItem.js
@@ -170,11 +170,11 @@ builder.add(function testDeleteAllItemsFromStringSet(test) {
     .deleteFromAttribute('someStringSet', ['a', 'b', 'c', 'd'])
     .execute()
     .then(function (data) {
-      test.deepEqual(data.result.someStringSet.length, 0, 'someStringSet length should be 0')
+      test.deepEqual(data.result.someStringSet, undefined, 'someStringSet should be undefined')
       return utils.getItemWithSDK(self.db, "userA", "@")
     })
     .then(function (data) {
-      test.deepEqual(data['Item']['someStringSet'].SS.length, 0, 'someStringSet length should be 0')
+      test.deepEqual(data['Item']['someStringSet'], undefined, 'someStringSet should be undefined')
     })
 })
 


### PR DESCRIPTION
Hello @sboora, @x-ma, 

I think something crazy was going on? Both Xiao and I are seeing this test as broken
and rolling back fixes it?

Please review the following commits I made in branch 'nick-tests'.

d593d623bf6ddde28f82da8300848c02e3829d5a (2013-11-18 15:41:41 -0500)
Revert "Fixed unit test testDeleteAllItemsFromStringSet"
This reverts commit 66b4e3ed7161c68ece37e694d626cd4aff71127e.

R=@sboora
R=@x-ma
