### PR TITLE
API additions to test query paging with FakeDynamoo

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -21,6 +21,17 @@ function FakeTable(name) {
     range: null
   }
   this.data = {}
+
+  /** @private {number} */
+  this._maxResultSetSize = MAX_GET_BATCH_ITEM_SIZE
+}
+
+/**
+ * Set a hard upper limit at the amount of results that queries and scans on this table can return.
+ * @param {number} maxResultSetSize
+ */
+FakeTable.prototype.setMaxResultSetSize = function (maxResultSetSize) {
+  this._maxResultSetSize = maxResultSetSize
 }
 
 /**
@@ -96,7 +107,7 @@ FakeTable.prototype.query = function(data) {
   var hash = data.HashKeyValue || parseAmazonAttribute(
     data.KeyConditions[this.primaryKey.hash.name].AttributeValueList[0]).value
   var indexedKeyValues = !!data.IndexName ? this._getIndexedKeyValuesForHash(hash, indexedKeyName) : this._getRangeKeyValuesForHash(hash)
-  var limit = data.Limit || -1
+  var limit = Math.min(data.Limit || Infinity, this._maxResultSetSize)
 
   if (data.ExclusiveStartKey) {
     var index = indexedKeyValues.indexOf(data.ExclusiveStartKey[indexedKeyName])
@@ -173,7 +184,7 @@ FakeTable.prototype.scan = function(data) {
   var hashKeyName = this.primaryKey.hash.name
   var rangeKeyName = this.primaryKey.range.name
   var sortedData = this._sortDataByPrimaryKey()
-  var limit = data.Limit || Infinity
+  var limit = Math.min(data.Limit || Infinity, this._maxResultSetSize)
   var attributes = this._getAttributesFromData(data)
   var exclusiveStartKey = data.ExclusiveStartKey ? typeUtil.unpackObjects(data.ExclusiveStartKey) : undefined
   var results = []
@@ -669,12 +680,13 @@ FakeDynamo.prototype.batchGetItem = function (data, callback) {
         throw new Error('ValidationException: Provided list of item keys contains duplicates')
       }
 
+      var table = this.getTable(tableName)
+      var limit = Math.min(table._maxResultSetSize, MAX_GET_BATCH_ITEM_SIZE)
       for (var i = 0; i < keys.length; i++) {
         count++
-        if (count <= MAX_GET_BATCH_ITEM_SIZE) {
+        if (count <= limit) {
           promises.push(
-            this.getTable(tableName)
-              .getItem({Item: keys[i], AttributesToGet: data.RequestItems[tableName].AttributesToGet})
+            table.getItem({Item: keys[i], AttributesToGet: data.RequestItems[tableName].AttributesToGet})
               .then(function (data) {
                 if (!(tableName in resp.Responses)) {
                   resp.Responses[tableName] = []

--- a/test/testFakeDynamo.js
+++ b/test/testFakeDynamo.js
@@ -253,9 +253,33 @@ builder.add(function testQueryWithLimit(test) {
     .setLimit(2)
     .execute()
     .then(function (data) {
-      test.equal(data.result[0].age, 28, "Age should match 28")
-      test.equal(data.result[1].age, 29, "Age should match 29")
-      test.equal(data.result.length, 2, '"4" should be returned')
+      test.equal(data.result[0].age, 28)
+      test.equal(data.result[1].age, 29)
+      test.equal(data.result.length, 2)
       test.deepEqual(data.LastEvaluatedKey, {userId: {S: 'userA'}, column: {S: '3'}})
+    })
+})
+
+builder.add(function testQueryWithMaxResultSize(test) {
+  db.getTable('user').setData({
+    'userA': {
+        '1': {userId: 'userA', column: '1', age: '27'},
+        '2': {userId: 'userA', column: '2', age: '28'},
+        '3': {userId: 'userA', column: '3', age: '29'},
+        '4': {userId: 'userA', column: '4', age: '30'}
+    }
+  })
+  db.getTable('user').setMaxResultSetSize(1)
+
+  return client.newQueryBuilder('user')
+    .setHashKey('userId', 'userA')
+    .setIndexName('age-index')
+    .indexGreaterThanEqual('age', 28)
+    .setLimit(2)
+    .execute()
+    .then(function (data) {
+      test.equal(data.result[0].age, 28)
+      test.equal(data.result.length, 1)
+      test.deepEqual(data.LastEvaluatedKey, {userId: {S: 'userA'}, column: {S: '2'}})
     })
 })


### PR DESCRIPTION
Hello @x-ma, 

Please review the following commits I made in branch 'nick-query'.

7ed419827bb1b179f1e9b041d3ac935c8b9b3a1b (2013-11-18 16:09:05 -0500)
Add an API on the table for setting query limits

fe43fcdf683329f0f626e557cf135a424e9a602a (2013-11-18 16:03:00 -0500)
Fix the query API so that it returns LastEvaluatedKey when there's a limit

R=@x-ma
