### PR TITLE
Classify error types in a more reliable way.

### DIFF
--- a/lib/BatchGetItemBuilder.js
+++ b/lib/BatchGetItemBuilder.js
@@ -169,7 +169,7 @@ BatchGetItemBuilder.prototype._getAllItems = function (queryData) {
       }
     })
     .setContext({data: queryData, isWrite: false})
-    .fail(common.convertErrors)
+    .fail(this.convertErrors)
     .clearContext()
 }
 

--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -163,26 +163,36 @@ Builder.prototype.prepareOutput = function (output) {
   return data
 }
 
-Builder.prototype.convertErrors = function (e, context) {
+Builder.prototype.convertErrors = function (err, context) {
+  // Errors in Dynamo response are JSON objects like this:
+  // {
+  //   "message":"Attribute found when none expected.",
+  //   "code":"ConditionalCheckFailedException",
+  //   "name":"ConditionalCheckFailedException",
+  //   "statusCode":400,
+  //   "retryable":false
+  // }
+  //
+  // More at http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html
+  //
+  // To be more reliable, we check both err.name and err.code.
+  // Dynamo doc specifies the value of "code", so the error object
+  // should have "code" assigned. The node.js SDK assigns "code"
+  // to "name". "name" is the standard attribute of javascript Error
+  // object, so we double-check it.
   var data = context.data
   var isWrite = !!context.isWrite
 
-  if (isConditionalError(e)) throw new errors.ConditionalError(data, e.message)
-  else if (isProvisioningError(e)) throw new errors.ProvisioningError(data, e.message, isWrite)
-  else if (isValidationError(e)) throw new errors.ValidationError(data, e.message, isWrite)
-  else throw e
-}
-
-function isConditionalError(e) {
-  return e.message && e.message.indexOf('conditional') !== -1
-}
-
-function isProvisioningError(e) {
-  return e.message && e.message.indexOf('provisioning') !== -1
-}
-
-function isValidationError(e) {
-  return e.message && e.message.indexOf('ValidationException') !== -1
+  switch (err.code || err.name) {
+    case 'ConditionalCheckFailedException':
+      throw new errors.ConditionalError(data, err.message)
+    case 'ProvisionedThroughputExceededException':
+      throw new errors.ProvisioningError(data, err.message, isWrite)
+    case 'ValidationException':
+      throw new errors.ValidationError(data, err.message, isWrite)
+    default:
+      throw err
+  }
 }
 
 module.exports = Builder

--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -8,6 +8,13 @@ var inspect = function (o) { return util.inspect(o, {depth: null, colors: true})
 /** @const */
 var MAX_GET_BATCH_ITEM_SIZE = 100
 
+function DynamoError(name, message) {
+  this.name = name
+  this.code = name
+  this.message = message
+}
+util.inherits(DynamoError, Error)
+
 /**
  * Fake table which can be used to store mock data and run queries
  *
@@ -457,12 +464,18 @@ FakeTable.prototype._checkExpected = function(expected, currentData) {
   for (var key in expected) {
     if (!typ.isNullish(expected[key].Exists) && !expected[key].Exists) {
       // if the field shouldn't exist
-      if (currentData && !typ.isNullish(currentData[key])) throw new Error('conditional request failed')
+      if (currentData && !typ.isNullish(currentData[key])) {
+        throw new DynamoError('ConditionalCheckFailedException', 'Attribute found when none expected.')
+      }
     } else {
       // if the field should match a specific value
-      if (!currentData) throw new Error('conditional request failed')
+      if (!currentData) {
+        throw new DynamoError('ConditionalCheckFailedException', 'Attribute missing when expected.')
+      }
       var attribute = parseAmazonAttribute(expected[key].Value)
-      if (currentData[key] !== attribute.value) throw new Error('conditional request failed')
+      if (currentData[key] !== attribute.value) {
+        throw new DynamoError('ConditionalCheckFailedException', 'Values are different than expected.')
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynamite",
   "description": "promise-based DynamoDB client",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "homepage": "https://github.com/Obvious/dynamite",
   "licenses" : [
     { "type": "Apache License, Version 2.0",

--- a/test/testFakeDynamo.js
+++ b/test/testFakeDynamo.js
@@ -5,7 +5,6 @@ var builder = new nodeunitq.Builder(exports)
 var Client = require('../lib/Client')
 var FakeDynamo = require('../lib/FakeDynamo')
 var typeUtil = require('../lib/TypeUtil')
-
 var utils = require('./utils/testUtils.js')
 
 var onError = console.error.bind(console)


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'xiao-more-reliable-error-classification'.

5692315dd9ebc63cbd68728309efda61bc504587 (2013-11-22 23:28:44 -0800)

Classify error types in a more reliable way.

The previou way we classify errors is not reliable -- check a particular
string in error message. This commit changes to check error code and
error name.

Check list:

R=@nicks
