### PR TITLE
Fix unit test cases to work with DynamoDB Local, except two

### DIFF
--- a/lib/BatchGetItemBuilder.js
+++ b/lib/BatchGetItemBuilder.js
@@ -67,7 +67,7 @@ BatchGetItemBuilder.prototype.execute = function () {
   var count = 0
   var batchTableKeys = {}
 
-  // Divde all the items to fetch into braches, BATCH_LIMIT (100) items each.
+  // Divide the items into batches, BATCH_LIMIT (100) items each.
   for (var tableName in this._tableKeys) {
     var keys = this._tableKeys[tableName]
     batchTableKeys[tableName] = []
@@ -163,8 +163,8 @@ BatchGetItemBuilder.prototype._getAllItems = function (queryData) {
             .returnConsumedCapacity()
             .build())
           .then(function (moreData) {
-            data.UnprocessedKeys = {}
             builder._mergeTwoBatches(data, moreData)
+            data.UnprocessedKeys = {}
             return data
           })
       } else {

--- a/lib/DynamoRequest.js
+++ b/lib/DynamoRequest.js
@@ -93,6 +93,10 @@ DynamoRequest.prototype.setFilter = function (filter) {
           AttributeValueList: values,
           ComparisonOperator: filter[key][0]
         }
+      } else if (filter[key][0] === 'NULL' || filter[key][0] === 'NOT_NULL') {
+        this.data.ScanFilter[key] = {
+          ComparisonOperator: filter[key][0]
+        }
       } else {
         this.data.ScanFilter[key] = {
           AttributeValueList: [typeUtil.valueToObject(filter[key][1])],

--- a/test/testBatchGetItem.js
+++ b/test/testBatchGetItem.js
@@ -30,12 +30,10 @@ for (var i = 0; i < 202; i++) {
 
 // Generate big items that will exceed amount allowed to be returned.
 var muchoData = []
-var junk = new Array(100000).join('.')
+var junk = new Array(62000).join('.')
 for (var i = 0; i < 101; i++) {
   muchoData.push({'hashKey': 'id' + i, 'column': '@', 'data': junk})
 }
-
-
 
 // basic setup for the tests, creating record userA with range key @
 exports.setUp = function (done) {
@@ -85,12 +83,8 @@ builder.add(function testBatchGet(test) {
     .requestItems('phones', [{'userId': 'userA', 'column': 'phone1'}, {'userId': 'userB', 'column': 'phone1'}])
     .execute()
     .then(function (data) {
-      test.equal(data.ConsumedCapacity.user, 1)
-      test.equal(data.ConsumedCapacity.phones, 1)
-
       var ages = data.result.user.map(function (user) { return user.age })
       test.deepEqual(ages, ['29', '44'])
-
       var phones = data.result.phones.map(function (phone) { return phone.number })
       test.deepEqual(phones, ['415-662-1234', '550-555-5555'])
     })

--- a/test/testDeleteItem.js
+++ b/test/testDeleteItem.js
@@ -3,6 +3,7 @@
 var utils = require('./utils/testUtils.js')
 var dynamite = require('../dynamite')
 var typ = require('typ')
+var errors = require('../lib/errors')
 var nodeunitq = require('nodeunitq')
 var builder = new nodeunitq.Builder(exports)
 
@@ -113,9 +114,7 @@ builder.add(function testDeleteExistingItemWithFailedConditional(test) {
     .then(function () {
       test.fail("'testDeleteExistingItemWithFailedConditional' failed")
     })
-    .fail(function (e) {
-      test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-    })
+    .fail(this.client.throwUnlessConditionalError)
 })
 
 // check that an item fails an absent conditional when deleting
@@ -133,9 +132,7 @@ builder.add(function testDeleteExistingItemWithFailedAbsentConditional(test) {
     .then(function () {
       test.fail("'testDeleteExistingItemWithFailedAbsentConditional' failed")
     })
-    .fail(function (e) {
-      test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-    })
+    .fail(this.client.throwUnlessConditionalError)
 })
 
 // check that non-existent items can't be deleted if a conditional expects a value
@@ -153,9 +150,7 @@ builder.add(function testDeleteNonexistingItemWithConditional(test) {
     .then(function (e) {
       test.fail("'testDeleteNonexistingItemWithConditional' failed")
     })
-    .fail(function (e) {
-      test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-    })
+    .fail(this.client.throwUnlessConditionalError)
 })
 
 // check that non-existent items can't be deleted if a conditional expects a value

--- a/test/testPutItem.js
+++ b/test/testPutItem.js
@@ -4,6 +4,7 @@ var utils = require('./utils/testUtils.js')
 var dynamite = require('../dynamite')
 var nodeunitq = require('nodeunitq')
 var builder = new nodeunitq.Builder(exports)
+var errors = require('../lib/errors')
 
 var onError = console.error.bind(console)
 var initialData = [{"userId": "userA", "column": "@", "age": "29"}]
@@ -147,9 +148,7 @@ builder.add(function testPutWithFailedConditional(test) {
   .then(function () {
     test.fail("'testPutWithFailedConditional' failed")
   })
-  .fail(function (e) {
-    test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-  })
+  .fail(this.client.throwUnlessConditionalError)
 })
 
 // put with failed conditional doesn't exist
@@ -169,9 +168,7 @@ builder.add(function testPutWithFailedConditionalForNoRecord(test) {
   .then(function () {
     test.fail("'testPutWithFailedConditionalForNoRecord' failed")
   })
-  .fail(function (e) {
-    test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-  })
+  .fail(this.client.throwUnlessConditionalError)
 })
 
 // put set with failed absent conditional exists
@@ -191,7 +188,5 @@ builder.add(function testPutWithFailedAbsentConditionalExists(test) {
   .then(function () {
     test.fail("'testPutWithFailedAbsentConditionalExists' failed")
   })
-  .fail(function (e) {
-    test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-  })
+  .fail(this.client.throwUnlessConditionalError)
 })

--- a/test/testPutSet.js
+++ b/test/testPutSet.js
@@ -1,5 +1,6 @@
 var utils = require('./utils/testUtils.js')
 var dynamite = require('../dynamite')
+var errors = require('../lib/errors')
 var nodeunitq = require('nodeunitq')
 var builder = new nodeunitq.Builder(exports)
 
@@ -202,9 +203,7 @@ builder.add(function testStringSetPutWithFailedConditional(test) {
   .then(function (data) {
     test.fail("'testStringSetPutWithFailedConditional' failed")
   })
-  .fail(function (e) {
-    test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-  })
+  .fail(this.client.throwUnlessConditionalError)
 })
 
 // put set with failed conditional doesn't exist
@@ -227,9 +226,7 @@ builder.add(function testStringSetPutWithFailedConditionalForNoRecord(test) {
   .then(function (data) {
     test.fail("'testStringSetPutWithFailedConditionalForNoRecord' failed")
   })
-  .fail(function (e) {
-    test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-  })
+  .fail(this.client.throwUnlessConditionalError)
 })
 
 // put set with failed absent conditional exists
@@ -252,7 +249,5 @@ builder.add(function testStringSetPutWithFailedConditionalExists(test) {
   .then(function (data) {
     test.fail("'testStringSetPutWithFailedConditionalForNoRecord' failed")
   })
-  .fail(function (e) {
-    test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-  })
+  .fail(this.client.throwUnlessConditionalError)
 })

--- a/test/testUpdateItem.js
+++ b/test/testUpdateItem.js
@@ -2,6 +2,7 @@
 
 var utils = require('./utils/testUtils.js')
 var dynamite = require('../dynamite')
+var errors = require('../lib/errors')
 var nodeunitq = require('nodeunitq')
 var builder = new nodeunitq.Builder(exports)
 
@@ -74,7 +75,7 @@ builder.add(function testPutAttributeNonExisting(test) {
     })
 })
 
-//test putting attributes with empty and null values
+//test putting attributes with empty would succeed
 builder.add(function testPutAttributeEmpty(test) {
   var self = this
   return this.client.newUpdateBuilder('user')
@@ -301,9 +302,7 @@ builder.add(function testUpdateFailsWithConditional(test) {
     .then(function (data) {
       test.fail("'testUpdateFailsWithConditional' failed - the query is expected to fail, but it didn't.")
     })
-    .fail(function (e) {
-      test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-    })
+    .fail(this.client.throwUnlessConditionalError)
 })
 
 // test updating fails with conditional doesnt exist
@@ -323,9 +322,7 @@ builder.add(function testUpdateFailsWithConditionalDoesNotExist(test) {
     .then(function (data) {
       test.fail("'testUpdateFailsWithConditionalDoesNotExist' failed - the query is expected to fail, but it didn't.")
     })
-    .fail(function (e) {
-      test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-    })
+    .fail(this.client.throwUnlessConditionalError)
 })
 
 // test updating fails with absent conditional exists
@@ -345,9 +342,7 @@ builder.add(function testUpdateFailsWithAbsentConditional(test) {
     .then(function (data) {
       test.fail("'testUpdateFailsWithAbsentConditional' failed - the query is expected to fail, but it didn't.")
     })
-    .fail(function (e) {
-      test.equal(e.message.indexOf('conditional') !== -1, true, "Conditional request should fail")
-    })
+    .fail(this.client.throwUnlessConditionalError)
 })
 
 builder.add(function testUpdateFailsWhenConditionalArgumentBad(test) {


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'xiao-using-DynamoDB-Local-for-testing'.

1dad1673c7678c1e36ed9f1f23273fed08c4ce30 (2013-11-25 20:48:01 -0800)
Fix unit test cases to work with DynamoDB Local, except two
The two test cases that still fail are probably caused by bugs in
DynamoDB Local.
1. UpdateItem calls succeed even when we update an attribute with
   an empty string. Based on the doc, empty strings and sets are
   now allowed.
2. BatchGetItem calls may return less unprocessed keys than expected.

Check list:

R=@nicks
