### PR TITLE
Make FakeDynamo return the right capacity information

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -180,7 +180,8 @@ FakeTable.prototype._formatPagedResults = function (results, queryData) {
   var filteredResults = this._filterByExclusiveStartKey(results, queryData)
 
   var limit = Math.min(queryData.Limit || Infinity, this._maxResultSetSize)
-  var ret = {ConsumedCapacity: 1}
+  var ret = {}
+
   if (filteredResults.length > limit) {
     ret.LastEvaluatedKey = this._createLastEvaluatedKey(filteredResults[limit - 1])
     filteredResults.length = limit
@@ -194,6 +195,7 @@ FakeTable.prototype._formatPagedResults = function (results, queryData) {
 
   var attributes = this._getAttributesFromData(queryData)
   ret.Items = typeUtil.packObjectOrArray(filteredResults, attributes)
+  ret.ConsumedCapacity = this._getCapacityBlob(ret.Items.length)
   return Q.resolve(ret)
 }
 
@@ -285,9 +287,10 @@ FakeTable.prototype.putItem = function(data) {
   // store the item
   this._putItemAtKey(key, obj)
 
+
   // done (ALL_NEW only returns ConsumedCapacity)
   return Q.resolve({
-    ConsumedCapacity: 1
+    ConsumedCapacity: this._getCapacityBlob(1)
   })
 }
 
@@ -390,13 +393,13 @@ FakeTable.prototype.updateItem = function(data) {
     // done (ALL_NEW only returns ConsumedCapacity)
     return Q.resolve({
       Attributes: typeUtil.packObjectOrArray(item),
-      ConsumedCapacity: 1
+      ConsumedCapacity: this._getCapacityBlob(1)
     })
   } else {
     // done (ALL_NEW only returns ConsumedCapacity)
     return Q.resolve({
       Attributes: {},
-      ConsumedCapacity: 1
+      ConsumedCapacity: this._getCapacityBlob(1)
     })
   }
 }
@@ -415,7 +418,7 @@ FakeTable.prototype.deleteItem = function(data) {
   }
   this._putItemAtKey(key, undefined)
   return Q.resolve({
-    ConsumedCapacity: 1
+    ConsumedCapacity: this._getCapacityBlob(1)
   })
 }
 
@@ -432,8 +435,18 @@ FakeTable.prototype.getItem = function(data) {
 
   return Q.resolve({
     Item: typeUtil.packObjectOrArray(item, attributes),
-    ConsumedCapacity: 1
+    ConsumedCapacity: this._getCapacityBlob(1)
   })
+}
+
+/**
+ * Get a JSON blob for the consumed capacity data.
+ */
+FakeTable.prototype._getCapacityBlob = function(n) {
+  return {
+    CapacityUnits: n,
+    TableName: this.name
+  }
 }
 
 /**


### PR DESCRIPTION
Hello @nicks, @dpup, 

Please review the following commits I made in branch 'xiao-FakeDynamo-capacity'.

30ee0fdea589a2568e5495a2643c628ecd189555 (2014-01-31 15:09:40 -0800)
Make FakeDynamo return the right capacity information
For more information - http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Operations.html

R=@nicks
R=@dpup
