### PR TITLE
Fix the consumed capacity of batchGetItems() in FakeDynamo

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -692,10 +692,11 @@ FakeDynamo.prototype.scan = performOp('scan')
 FakeDynamo.prototype.batchGetItem = function (data, callback) {
   var promises = []
   var unprocessedKeys = {}
-  var resp = {Responses: {}, UnprocessedKeys: {}}
+  var resp = {Responses: {}, UnprocessedKeys: {}, ConsumedCapacity: []}
   this.stats.batchGetItem += 1
 
   try {
+    // the number of fetched object across all tables.
     var count = 0
     for (var tableName in data.RequestItems) {
       var keys = data.RequestItems[tableName].Keys
@@ -711,7 +712,9 @@ FakeDynamo.prototype.batchGetItem = function (data, callback) {
 
       var table = this.getTable(tableName)
       var limit = Math.min(table._maxResultSetSize, MAX_GET_BATCH_ITEM_SIZE)
+      var countPerTable = 0
       for (var i = 0; i < keys.length; i++) {
+        countPerTable++
         count++
         if (count <= limit) {
           promises.push(
@@ -732,6 +735,7 @@ FakeDynamo.prototype.batchGetItem = function (data, callback) {
           resp.UnprocessedKeys[tableName].Keys.push(keys[i])
         }
       }
+      resp.ConsumedCapacity.push(table._getCapacityBlob(countPerTable))
     }
     this.stats.batchGetItemCount.push(count)
 


### PR DESCRIPTION
Hello @nicks, @giannic, 

Please review the following commits I made in branch 'xiao-fix-capaciy-batchget'.

42eee2728684d269893108bdf12f407889a2d8ac (2014-02-26 15:04:56 -0800)
Fix the consumed capacity of batchGetItems() in FakeDynamo

R=@nicks
R=@giannic
