### PR TITLE
Roll AWS SDK version back to 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynamite",
   "description": "promise-based DynamoDB client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "homepage": "https://github.com/Obvious/dynamite",
   "licenses" : [
     { "type": "Apache License, Version 2.0",
@@ -28,7 +28,7 @@
   "dependencies": {
     "kew": "0.3.3",
     "typ": "0.6.2",
-    "aws-sdk": "1.18.0"
+    "aws-sdk": "1.15.0"
   },
   "devDependencies": {
     "nodeunit": "0.7.4",


### PR DESCRIPTION
Hello @giannic, 

Please review the following commits I made in branch 'xiao-rollback-sdk'.

27a244dcdf5f2dcd603cc686db3b771ec659ff13 (2014-03-02 23:19:45 -0800)
Roll AWS SDK version back to 1.15.0
We experienced performance regression in the 1.18.0 version of AWS SDK,
so we have to roll back to 1.15.0, which doesn't have the regression
and supports GSI.

R=@giannic
