### PR TITLE
Add APIs to expose the hash key name and range key name of a query builder

### DIFF
--- a/lib/QueryBuilder.js
+++ b/lib/QueryBuilder.js
@@ -4,6 +4,7 @@ var DynamoRequest = require('./DynamoRequest')
 var DynamoResponse = require('./DynamoResponse')
 var Builder = require('./Builder')
 var Q = require('kew')
+var IndexNotExistError = require('./errors').IndexNotExistError
 
 /**
  * @param {Object} options
@@ -18,12 +19,32 @@ function QueryBuilder(options) {
 }
 require('util').inherits(QueryBuilder, Builder)
 
+/**
+ * If this query runs on a local index or global index, set a
+ * function that can generate an index name based on query
+ * conditions.
+ *
+ * @param {Function(string, string): string} fn The generator function
+ */
+QueryBuilder.prototype.setIndexNameGenerator = function (fn) {
+  this._indexNameGenerator = fn
+}
+
 QueryBuilder.prototype.setHashKey = function (name, val) {
-  return this.indexEquals(name, val)
+  if (typ.isNullish(val)) throw new Error('Invalid hash key value: ' + val)
+  this._hashKeyName = name
+  // The condition on the hash key is always an 'EQ'
+  this._keyConditions.push({
+    name: name,
+    operator: 'EQ',
+    attributes: [ val ]
+  })
+  return this
 }
 
 QueryBuilder.prototype.indexBeginsWith = function (name, prefix) {
-  if (typ.isNullish(prefix)) throw new Error("Key must be defined")
+  this._rangeKeyName = name
+  if (typ.isNullish(prefix)) throw new Error('Key must be defined')
   this._keyConditions.push({
     name: name,
     operator: 'BEGINS_WITH',
@@ -33,7 +54,8 @@ QueryBuilder.prototype.indexBeginsWith = function (name, prefix) {
 }
 
 QueryBuilder.prototype.indexEquals = function (name, val) {
-  if (typ.isNullish(val)) throw new Error("Invalid range key")
+  if (typ.isNullish(val)) throw new Error('Invalid value for the range key: ' + val)
+  this._rangeKeyName = name
   this._keyConditions.push({
     name: name,
     operator: 'EQ',
@@ -44,7 +66,8 @@ QueryBuilder.prototype.indexEquals = function (name, val) {
 QueryBuilder.prototype.indexEqual = QueryBuilder.prototype.indexEquals
 
 QueryBuilder.prototype.indexLessThanEqual = function (name, val) {
-  if (typ.isNullish(val)) throw new Error("Invalid range key")
+  if (typ.isNullish(val)) throw new Error('Invalid value for the range key: ' + val)
+  this._rangeKeyName = name
   this._keyConditions.push({
     name: name,
     operator: 'LE',
@@ -55,7 +78,8 @@ QueryBuilder.prototype.indexLessThanEqual = function (name, val) {
 }
 
 QueryBuilder.prototype.indexLessThan = function (name, val) {
-  if (typ.isNullish(val)) throw new Error("Invalid range key")
+  if (typ.isNullish(val)) throw new Error('Invalid value for the range key: ' + val)
+  this._rangeKeyName = name
   this._keyConditions.push({
     name: name,
     operator: 'LT',
@@ -65,7 +89,8 @@ QueryBuilder.prototype.indexLessThan = function (name, val) {
 }
 
 QueryBuilder.prototype.indexGreaterThanEqual = function (name, val) {
-  if (typ.isNullish(val)) throw new Error("Invalid range key")
+  if (typ.isNullish(val)) throw new Error('Invalid value for the range key: ' + val)
+  this._rangeKeyName = name
   this._keyConditions.push({
     name: name,
     operator: 'GE',
@@ -76,7 +101,8 @@ QueryBuilder.prototype.indexGreaterThanEqual = function (name, val) {
 QueryBuilder.prototype.indexGreaterThanEquals = QueryBuilder.prototype.indexGreaterThanEqual
 
 QueryBuilder.prototype.indexGreaterThan = function (name, val) {
-  if (typ.isNullish(val)) throw new Error("Invalid range key")
+  if (typ.isNullish(val)) throw new Error('Invalid value for the range key: ' + val)
+  this._rangeKeyName = name
   this._keyConditions.push({
     name: name,
     operator: 'GT',
@@ -86,8 +112,9 @@ QueryBuilder.prototype.indexGreaterThan = function (name, val) {
 }
 
 QueryBuilder.prototype.indexBetween = function (name, val1, val2) {
-  if (typ.isNullish(val1)) throw new Error("Invalid range key 1")
-  if (typ.isNullish(val2)) throw new Error("Invalid range key 2")
+  if (typ.isNullish(val1)) throw new Error('Invalid lower bound for the range key: ' + val)
+  if (typ.isNullish(val2)) throw new Error('Invalid upper bound for the range key: ' + val)
+  this._rangeKeyName = name
   this._keyConditions.push({
     name: name,
     operator: 'BETWEEN',
@@ -101,6 +128,11 @@ QueryBuilder.prototype.setStartKey = function (key) {
   return this
 }
 
+/**
+ * Set the index name of this query.
+ *
+ * @param {string} indexName
+ */
 QueryBuilder.prototype.setIndexName = function (indexName) {
   this._indexName = indexName
   return this
@@ -139,9 +171,17 @@ QueryBuilder.prototype.execute = function () {
     query.setRangeKey.apply(query, this._rangeKeyCondition)
   }
 
+  if (this._indexNameGenerator) {
+    var indexName = this._indexNameGenerator(this._hashKeyName, this._rangeKeyName)
+    if (!indexName) {
+      throw new IndexNotExistError(this._hashKeyName, this._rangeKeyName)
+    }
+    this.setIndexName(indexName)
+  }
+
   var queryData = query.build()
 
-  return this.request("query", queryData)
+  return this.request('query', queryData)
     .then(this.prepareOutput.bind(this))
     .fail(this.emptyResults)
     .setContext({attributes: queryData, isWrite: false})

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -47,8 +47,18 @@ function ValidationError(data, msg, isWrite) {
 util.inherits(ValidationError, Error)
 ValidationError.prototype.type = 'ValidationError'
 
+/** @constructor */
+function IndexNotExistError(hashKeyName, rangeKeyName) {
+  this.hashKeyName = hashKeyName
+  this.rangeKeyName = rangeKeyName
+}
+util.inherits(ValidationError, Error)
+IndexNotExistError.prototype.type = 'IndexNotExistError'
+
+
 module.exports = {
   ConditionalError: ConditionalError,
   ProvisioningError: ProvisioningError,
-  ValidationError: ValidationError
+  ValidationError: ValidationError,
+  IndexNotExistError: IndexNotExistError
 }


### PR DESCRIPTION
Hello @nicks, @giannic, 

Please review the following commits I made in branch 'xiao-query-api'.

7d665cfd512a39bedc98a7acf645d57eeb5f02b3 (2014-03-03 00:00:33 -0800)
Generate the default index name based on hash key and range key names

R=@nicks
R=@giannic
