### PR TITLE
removing unused param from getData in FakeDynamo

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -63,7 +63,7 @@ FakeTable.prototype.setData = function(data) {
  *
  * @return {Object} data
  */
-FakeTable.prototype.getData = function(data) {
+FakeTable.prototype.getData = function() {
   return this.data
 }
 


### PR DESCRIPTION
Hello @x-ma, 

Please review the following commits I made in branch 'giannic-fix'.

8956085786d09a1acb5907eb4197bc13f10538f4 (2014-05-06 10:06:06 -0700)
removing unused param from getData in FakeDynamo

R=@x-ma
