### PR TITLE
Sort range keys in FakeDynamo before selection

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -131,7 +131,7 @@ FakeTable.prototype.query = function(data) {
              parseAmazonAttribute(data.KeyConditions[this.primaryKey.hash.name].AttributeValueList[0]).value
 
   var indexedKeyValues = !!data.IndexName ? this._getIndexedKeyValuesForHash(hash, indexedKeyName) : this._getRangeKeyValuesForHash(hash)
-
+  indexedKeyValues.sort()
   // maybe add some stuff for secondary indices like
   // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html
   // var indexName = data.IndexName || 'primary'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynamite",
   "description": "promise-based DynamoDB client",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "homepage": "https://github.com/Medium/dynamite",
   "licenses" : [
     { "type": "Apache License, Version 2.0",

--- a/test/testFakeDynamo.js
+++ b/test/testFakeDynamo.js
@@ -180,6 +180,64 @@ builder.add(function testQueryOnSecondaryIndexGreaterThan(test) {
     })
 })
 
+// test querying secondary index using less than condition
+builder.add(function testQueryOnSecondaryIndexLessThan(test) {
+  db.getTable('user').setData({
+    'userA': {
+        0: {userId: 'userA', column: 0, age: 27},
+        1: {userId: 'userA', column: 1, age: 26},
+        2: {userId: 'userA', column: 2, age: 28},
+        3: {userId: 'userA', column: 3, age: 30},
+        4: {userId: 'userA', column: 4, age: 29},
+    },
+    'userB': {
+        1: {userId: 'userB', column: '1', age: 29},
+    }
+  })
+  return client.newQueryBuilder('user')
+    .setHashKey('userId', 'userA')
+    .setIndexName('age-index')
+    .indexLessThan('age', 29)
+    .scanBackward()
+    .execute()
+    .then(function (data) {
+      test.equal(data.result[0].age, 28, 'First entry should be 28')
+      test.equal(data.result[1].age, 27, 'Second entry should be 27')
+      test.equal(data.result[2].age, 26, 'Third entry should be 26')
+      test.equal(data.result.length, 3, '3 results should be returned')
+    })
+})
+
+// test querying secondary index using less than equals condition
+builder.add(function testQueryOnSecondaryIndexLessThanEquals(test) {
+  db.getTable('user').setData({
+    'userA': {
+        0: {userId: 'userA', column: 0, age: 27},
+        1: {userId: 'userA', column: 1, age: 26},
+        2: {userId: 'userA', column: 2, age: 28},
+        3: {userId: 'userA', column: 3, age: 29},
+        4: {userId: 'userA', column: 4, age: 30},
+    },
+    'userB': {
+        1: {userId: 'userB', column: '1', age: 29},
+    }
+  })
+  return client.newQueryBuilder('user')
+    .setHashKey('userId', 'userA')
+    .setIndexName('age-index')
+    .indexLessThanEqual('age', 29)
+    .scanBackward()
+    .execute()
+    .then(function (data) {
+      test.equal(data.result[0].age, 29, 'First entry should be 29')
+      test.equal(data.result[1].age, 28, 'Second entry should be 28')
+      test.equal(data.result[2].age, 27, 'Third entry should be 27')
+      test.equal(data.result[3].age, 26, 'Fourth entry should be 26')
+      test.equal(data.result.length, 4, '4 results should be returned')
+    })
+})
+
+
 // test querying secondary index using equals condition
 builder.add(function testQueryOnSecondaryIndexEquals(test) {
   db.getTable('user').setData({


### PR DESCRIPTION
Hello @x-ma, @giannic, 

Please review the following commits I made in branch 'satya-secondaryIndex'.

8605892940ea1655eba11822e0a2fc1248de7982 (2014-08-29 12:56:46 -0700)
Sort range keys in FakeDynamo before selection

R=@x-ma
R=@giannic
