### PR TITLE
allow GetItem on tables without rangekey

### DIFF
--- a/lib/GetItemBuilder.js
+++ b/lib/GetItemBuilder.js
@@ -17,10 +17,12 @@ GetItemBuilder.prototype.execute = function () {
     .setTable(this._tablePrefix, this._table)
     .returnConsumedCapacity()
     .setConsistent(this._isConsistent)
-    .setHashKey(this._hashKey, true)
-    .setRangeKey(this._rangeKey, true)
-    .selectAttributes(this._attributes)
-    .build()
+    .setHashKey(this._hashKey, true);
+
+  if (this.__rangeKey)
+    queryData.setRangeKey(this._rangeKey, true)
+
+  queryData = queryData.selectAttributes(this._attributes).build()
 
   return this.request("getItem", queryData)
     .then(this.prepareOutput.bind(this))


### PR DESCRIPTION
Here's an issue about dynamite's lack of support for tables without range keys: https://github.com/Medium/dynamite/issues/19

Eventually I'd like to get everything working on tables with just hash keys, but here's a quick fix for GetItem.
