### PR TITLE
Use GSIs in FakeDynamo when the IndexName starts with 'gsi'.

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -112,7 +112,10 @@ FakeTable.prototype.query = function(data) {
   var indexedKeyName
   if (!!data.IndexName) {
     // Global Secondary Index if hash key doesn't exist as either key condition
-    if (!data.KeyConditions.hasOwnProperty(this.primaryKey.hash.name)) {
+    var hashKeyInKeyConditions = data.KeyConditions.hasOwnProperty(this.primaryKey.hash.name)
+    var indexParts = data.IndexName.split('-')
+    var probableGSIIndex = indexParts.length >= 3
+    if (!hashKeyInKeyConditions || probableGSIIndex) {
       return this._queryGlobalSecondaryIndex(data)
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynamite",
   "description": "promise-based DynamoDB client",
-  "version": "0.6.8-alpha",
+  "version": "0.6.9-alpha",
   "homepage": "https://github.com/Medium/dynamite",
   "licenses" : [
     { "type": "Apache License, Version 2.0",

--- a/test/testFakeDynamo.js
+++ b/test/testFakeDynamo.js
@@ -261,6 +261,30 @@ builder.add(function testQueryOnSecondaryIndexEquals(test) {
     })
 })
 
+// test querying secondary index using equals condition
+builder.add(function testQueryOnGlobalSecondaryIndexEquals(test) {
+  db.getTable('user').setData({
+    'userA': {
+        1: {userId: 'userA', column: 1, age: 27},
+        2: {userId: 'userA', column: 2, age: 28},
+        3: {userId: 'userA', column: 3, age: 29},
+        4: {userId: 'userA', column: 4, age: 30},
+    },
+    'userB': {
+        1: {userId: 'userB', column: '1', age: 29},
+    }
+  })
+  return client.newQueryBuilder('user')
+    .setHashKey('age', 27)
+    .setIndexName('age-userId-index')
+    .indexBeginsWith('userId', 'user')
+    .execute()
+    .then(function (data) {
+      test.equal(data.result[0].age, 27, 'Age should match 28')
+      test.equal(data.result.length, 1, '1 result should be returned')
+    })
+})
+
 // test querying secondary index that have repeated column values
 // this is a test for a regression where fake dynamo may reinsert values
 // when the keys match again


### PR DESCRIPTION
Hello @x-ma, @giannic, @chaosgame, @sboora, 

Please review the following commits I made in branch 'jamie-gsi-with-table-hash-key-as-range-key'.

36fa3578e1fc79d1df69f9932ea67594d939f74d (2014-11-19 23:51:18 -0800)
Use GSIs in FakeDynamo when the IndexName starts with 'gsi'.

The existing FakeDynamo code doesn't make use of a GSI if the
range key of the GSI is the hash key of the table. This makes it
impossible to test queries against GSI where this is the case. As
a minimal addition, this patch explicitly uses the GSI path if
the indexName starts with 'gsi'.

R=@x-ma
R=@giannic
R=@chaosgame
R=@sboora
