### PR TITLE
support omitting range key where appropriate

### DIFF
--- a/lib/DeleteItemBuilder.js
+++ b/lib/DeleteItemBuilder.js
@@ -13,13 +13,15 @@ function DeleteItemBuilder(options) {
 require('util').inherits(DeleteItemBuilder, Builder)
 
 DeleteItemBuilder.prototype.execute = function () {
-  var queryData = new DynamoRequest(this.getOptions())
+  var req = new DynamoRequest(this.getOptions())
     .setTable(this._tablePrefix, this._table)
     .returnConsumedCapacity()
     .setHashKey(this._hashKey, true)
-    .setRangeKey(this._rangeKey, true)
     .setExpected(this._conditions)
-    .build()
+    
+  if (this._rangeKey) req.setRangeKey(this._rangeKey, true)
+
+  var queryData = req.build()
 
   return this.request("deleteItem", queryData)
     .then(this.prepareOutput.bind(this))

--- a/lib/GetItemBuilder.js
+++ b/lib/GetItemBuilder.js
@@ -13,14 +13,16 @@ function GetItemBuilder(options) {
 require('util').inherits(GetItemBuilder, Builder)
 
 GetItemBuilder.prototype.execute = function () {
-  var queryData = new DynamoRequest(this.getOptions())
+  var req = new DynamoRequest(this.getOptions())
     .setTable(this._tablePrefix, this._table)
     .returnConsumedCapacity()
     .setConsistent(this._isConsistent)
     .setHashKey(this._hashKey, true)
-    .setRangeKey(this._rangeKey, true)
     .selectAttributes(this._attributes)
-    .build()
+
+  if (this._rangeKey) req.setRangeKey(this._rangeKey, true)
+
+  var queryData = req.build()
 
   return this.request("getItem", queryData)
     .then(this.prepareOutput.bind(this))

--- a/lib/UpdateBuilder.js
+++ b/lib/UpdateBuilder.js
@@ -54,15 +54,17 @@ UpdateBuilder.prototype.deleteAttribute = function (key) {
 
 UpdateBuilder.prototype.execute = function () {
   var self = this
-  var queryData = new DynamoRequest(this.getOptions())
+  var req = new DynamoRequest(this.getOptions())
     .setTable(this._tablePrefix, this._table)
     .returnConsumedCapacity()
     .setHashKey(this._hashKey, true)
-    .setRangeKey(this._rangeKey, true)
     .setUpdates(this._attributes)
     .setExpected(this._conditions)
     .setReturnValues("ALL_NEW")
-    .build()
+
+  if (this._rangeKey) req.setRangeKey(this._rangeKey, true)
+
+  var queryData = req.build()
 
   if ((!this._conditions || !this._conditions.length) && !this._enabledUpsert) {
     console.warn("Update issued without conditions or .enableUpsert() called")

--- a/test/testHashKeyOnly.js
+++ b/test/testHashKeyOnly.js
@@ -1,0 +1,88 @@
+// Copyright 2013 The Obvious Corporation.
+var AWS = require('aws-sdk');
+var utils = require('./utils/testUtils.js')
+var dynamite = require('../dynamite')
+var typ = require('typ')
+var errors = require('../lib/errors')
+var nodeunitq = require('nodeunitq')
+var builder = new nodeunitq.Builder(exports)
+
+var onError = function (err) {
+  console.error(err.stack)
+}
+var initialData = [{"userId": "userA", "column": "@", "age": "29"}]
+
+// basic setup for the tests, creating record userA with range key @
+exports.setUp = function (done) {
+  var self = this
+  this.db = utils.getMockDatabase()
+  this.client = utils.getMockDatabaseClient()
+  utils.createTable(self.db, "userRangeOnly", "userId")
+    .thenBound(utils.initTable, null, {db: self.db, tableName: "userRangeOnly", data: initialData})
+    .fail(onError)
+    .fin(done)
+}
+
+exports.tearDown = function (done) {
+  utils.deleteTable(this.db, 'userRangeOnly')
+    .fin(done)
+}
+
+// check that an item exists
+builder.add(function testItemExists(test) {
+  return this.client.getItem('userRangeOnly')
+    .setHashKey('userId', 'userA')
+    .execute()
+    .then(function (data) {
+      test.equal(data.result.age, 29, 'Age should match the provided age')
+    })
+})
+
+// put an item and check that it exists
+builder.add(function testSimplePut(test) {
+  var self = this
+  return this.client.putItem("userRangeOnly", {
+    userId: 'userB',
+    column: '@',
+    age: 30
+  })
+  .execute()
+  .then(function () {
+    return utils.getItemWithSDK(self.db, "userB", null, 'userRangeOnly')
+  })
+  .then(function (data) {
+    test.equal(data['Item']['age'].N, "30", "Age should be set")
+  })
+})
+
+// put a list of strings and check if they exist
+builder.add(function testStringSetPut(test) {
+  var self = this
+  return this.client.putItem("userRangeOnly", {
+    userId: 'userC',
+    column: '@',
+    postIds: ['3a', '3b', '3c']
+  })
+  .execute()
+  .then(function () {
+    return utils.getItemWithSDK(self.db, "userC", null, 'userRangeOnly')
+  })
+  .then(function (data) {
+    test.deepEqual(data['Item']['postIds'].SS, ['3a', '3b', '3c'], "postIds should be ['3a', '3b', '3c']")
+  })
+})
+
+builder.add(function testDeleteItem(test) {
+  //AWS.config.logger = process.stdout
+
+  var self = this
+  return self.client.deleteItem('userRangeOnly')
+    .setHashKey('userId', 'userA')
+    .execute()
+    .then(function (data) {
+      return utils.getItemWithSDK(self.db, "userA", null, "userRangeOnly")
+    })
+    .then(function (data) {
+      test.equal(data['Item'], undefined, "User should be deleted~~~" + JSON.stringify(data))
+    })
+})

--- a/test/testHashKeyOnly.js
+++ b/test/testHashKeyOnly.js
@@ -72,6 +72,28 @@ builder.add(function testStringSetPut(test) {
   })
 })
 
+// test putting an attribute for an existing record
+builder.add(function testPutAttributeExisting(test) {
+  var self = this
+
+  return this.client.newUpdateBuilder('userRangeOnly')
+    .setHashKey('userId', 'userA')
+    .enableUpsert()
+    .putAttribute('age', 30)
+    .putAttribute('height', 72)
+    .execute()
+    .then(function (data) {
+      test.equal(data.result.age, 30, 'result age should be 30')
+      test.equal(data.result.height, 72, 'height should be 72')
+      return utils.getItemWithSDK(self.db, "userA", null, 'userRangeOnly')
+    })
+    .then(function (data) {
+      test.equal(data['Item']['age'].N, "30", "result age should be 30")
+      test.equal(data['Item']['height'].N, "72", "height should be 72")
+    })
+})
+
+
 builder.add(function testDeleteItem(test) {
   //AWS.config.logger = process.stdout
 


### PR DESCRIPTION
This PR adds support for getItem, deleteItem, updates using only a hash key. It should solve the #19 and is a fuller implementation of #51, which was closed by the author before review, merging.

I've added tests to a new test suite for this case, and I'm pretty sure I've tested the cases needed to ensure this is working (by copying and ever so slightly revising tests from other suites), but please let me know if there's some other case I'm missing.

A more general API for describing table structure w/constraints described in #19 might be useful, but something like this PR would be necessary anyway.
