### PR TITLE
Allow GSIs that share the same hash key as the main table and sort GSI query results in FakeDynamo

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -111,11 +111,11 @@ FakeTable.prototype.setRangeKey = function(name, type) {
 FakeTable.prototype.query = function(data) {
   var indexedKeyName
   if (!!data.IndexName) {
-    // Global Secondary Index if hash key doesn't exist as either key condition
-    var hashKeyInKeyConditions = data.KeyConditions.hasOwnProperty(this.primaryKey.hash.name)
+    // Global Secondary Index if the index name has three or more
+    // parts (separated by '-')
     var indexParts = data.IndexName.split('-')
     var probableGSIIndex = indexParts.length >= 3
-    if (!hashKeyInKeyConditions || probableGSIIndex) {
+    if (probableGSIIndex) {
       return this._queryGlobalSecondaryIndex(data)
     }
 
@@ -221,6 +221,23 @@ FakeTable.prototype._queryGlobalSecondaryIndex = function(data) {
       }
     }
   }
+
+  // sort by the range key of the GSI (if there is any)
+  var sortByKey
+  for (var key in data.KeyConditions) {
+    if (data.KeyConditions[key].ComparisonOperator != 'EQ') {
+      sortByKey = key
+      break
+    }
+  }
+  if (sortByKey) {
+    results.sort(function (a, b) {
+      return data.ScanIndexForward ?
+        a[sortByKey] - b[sortByKey] :
+        b[sortByKey] - a[sortByKey]
+    })
+  }
+
   return this._formatPagedResults(results, data)
 }
 


### PR DESCRIPTION
Hello @kylehg, @nicks, 

Please review the following commits I made in branch 'xiao-gsi-fake'.

a573ac95b9c272f7156ab42e0ba7332a5a56e07a (2015-02-18 11:14:48 -0800)
Allow GSIs that share the same hash key as the main table and sort GSI query results in FakeDynamo

R=@kylehg
R=@nicks

Code Review Checklist: 
- [ ] Pull Request has appropriate QA Notes 
- [ ] Commits are adequately tested 
- [ ] Code is easy to understand and conforms to our [style guides](https://github.com/Medium/docs/tree/master/style-guide) 
- [ ] Incomplete code, if applicable, is marked with TODOs 
- [ ] Logging and metrics are suitable 