### PR TITLE
Return an empty object when the amazon value is falsy

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -869,9 +869,13 @@ FakeDynamo.prototype.describeTable = function (tableData, callback) {
  * @return {{type:string, value:Object}}
  */
 function parseAmazonAttribute(attribute) {
-  return {
-    type: typeUtil.objectToType(attribute),
-    value: typeUtil.objectToValue(attribute)
+  if ('object' != typeof attribute || Object.keys(attribute).length == 0) {
+    return {}
+  } else {
+    return {
+      type: typeUtil.objectToType(attribute),
+      value: typeUtil.objectToValue(attribute)
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynamite",
   "description": "promise-based DynamoDB client",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "homepage": "https://github.com/Medium/dynamite",
   "licenses" : [
     { "type": "Apache License, Version 2.0",

--- a/test/testFakeDynamo.js
+++ b/test/testFakeDynamo.js
@@ -518,6 +518,27 @@ builder.add(function testQueryFiltering(test) {
     })
 })
 
+builder.add(function testDeleteItem(test) {
+  var conditions = client.newConditionBuilder()
+    .expectAttributeEquals('userId', 'userA')
+
+  return client.newUpdateBuilder('user')
+    .setHashKey('userId', 'userA')
+    .setRangeKey('column', '@')
+    .withCondition(conditions)
+    .deleteAttribute('age')
+    .execute()
+    .then(function () {
+      return client.getItem('user')
+        .setHashKey('userId', 'userA')
+        .setRangeKey('column', '@')
+        .execute()
+    })
+    .then(function (data) {
+      test.equal(data.result.age, undefined)
+    })
+})
+
 builder.add(function testLongKey(test) {
   // Create a string 2^10 chars long.
   var str = '.'


### PR DESCRIPTION
Hello @kylehg, @xiao, 

Please review the following commits I made in branch 'nathan-filtering'.

c69cdc7ddd0343a2b91727c683e3ee2ea04a052d (2015-07-27 13:17:12 -0700)
Return an empty object when the amazon value is falsy
(This was the subtle previous behavior.  Put it back so that FakeDynamo
continues to work.)

R=@kylehg
R=@xiao

Test plan: 'not tested'