### PR TITLE
Add request statistics to Dynamite

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -125,12 +125,30 @@ Builder.prototype.request = function (method, data) {
 
   var retryHandler = this.getRetryHandler()
   var table = this._table
-  if (retryHandler) {
-    req.on('retry', function () {
-      retryHandler(method, table)
+
+  var processingStartedAt, byteLength
+
+  // FakeDynamo doesn't return a request object
+  if (req && req.on) {
+    req.on('httpDone', function (res) {
+      processingStartedAt = Date.now()
+      byteLength = res.httpResponse.headers['content-length'] ||
+        Buffer.byteLength(res.httpResponse.body, 'utf8')
     })
+
+    if (retryHandler) {
+      req.on('retry', function () {
+        retryHandler(method, table)
+      })
+    }
   }
-  return defer.promise
+
+  return defer.then(function (output) {
+    output.ByteLength = byteLength
+    output.ProcessingStartedAt = processingStartedAt
+
+    return output
+  })
 }
 
 Builder.prototype.logQuery = function (method, data) {

--- a/lib/DynamoResponse.js
+++ b/lib/DynamoResponse.js
@@ -16,6 +16,8 @@ var DynamoResponse = function (tablePrefix, output, repeatWithStartKey) {
 
   this.ConsumedCapacityUnits = output.ConsumedCapacityUnits
   this.Count = output.Count
+  this.ProcessingStartedAt = output.ProcessingStartedAt
+  this.ByteLength = output.ByteLength
 
   this.LastEvaluatedKey = undefined
   if (output.LastEvaluatedKey) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynamite",
   "description": "promise-based DynamoDB client",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "homepage": "https://github.com/Medium/dynamite",
   "licenses" : [
     { "type": "Apache License, Version 2.0",


### PR DESCRIPTION
Hello @xiao, @dpup, 

Please review the following commits I made in branch 'nathan-perf'.

6fbf1527d2eda947d9ab58bb6439052fba394b92 (2015-07-31 10:03:39 -0700)
Add request statistics to Dynamite
`httpDone` is the event emitted when we've recieved all data but AWS-SDK
hasn't parsed it yet.  `complete` emitted aftere the parsing is done (or
has failed).  Buffer.byteLength is unfortunately O(n), and is about 13ms
for 6MB of data (which should be okay since requests that return 6MB of
data are expensive anyways -- the same request took ~140ms to parse).

R=@xiao
R=@dpup

Test plan: 'not tested'