### PR TITLE
Fix BOOL handling

### DIFF
--- a/lib/typeUtil.js
+++ b/lib/typeUtil.js
@@ -85,11 +85,7 @@ function valueToObject(value) {
   case 'string':
     return {S: value}
   case 'boolean':
-    var b = Boolean(value);
-    if (value === 'false') {
-      b = false;
-    }
-    return {BOOL: b}
+    return {BOOL: Boolean(value)}
   case 'number':
     return {N: String(value)}
   default:

--- a/lib/typeUtil.js
+++ b/lib/typeUtil.js
@@ -23,7 +23,7 @@ var typ = require('typ')
  *
  * @typedef {{
  *   B: (string|undefined),
- *   BOOL: (string|undefined),
+ *   BOOL: (boolean|undefined),
  *   BS: (Array.<string>|undefined),
  *   N: (string|undefined),
  *   NS: (Array.<string>|undefined),
@@ -85,7 +85,11 @@ function valueToObject(value) {
   case 'string':
     return {S: value}
   case 'boolean':
-    return {BOOL: String(value)}
+    var b = Boolean(value);
+    if (value === 'false') {
+      b = false;
+    }
+    return {BOOL: b}
   case 'number':
     return {N: String(value)}
   default:


### PR DESCRIPTION
Since at least https://github.com/aws/aws-sdk-js/commit/7c30e3c5ea061cbb7ab814b979b9895d958f678b, the AWS SDK only accepts boolean values for the BOOL type.  This change updates typeUtils to reflect this, and fixes #78 .

The line in question is https://github.com/aws/aws-sdk-js/blob/master/apis/dynamodb-2012-08-10.normal.json#L429