### PR TITLE
Convert objects to DynamoDB Maps for storage

### DIFF
--- a/lib/typeUtil.js
+++ b/lib/typeUtil.js
@@ -111,6 +111,8 @@ function valueToObject(value) {
       } else {
         throw new Error('Invalid dynamo set value. Type: ' + firstItemType + ', Value: ' + value[0])
       }
+    } else if (typeof value == "object") {
+      return {M: packObjectOrArray(value)};
     } else {
       // TODO(nick): I'm pretty sure this should be an error. But there is a bunch
       // of code relying on this behavior, so just log the error for now and


### PR DESCRIPTION
Looks like the code for reading maps from DynamoDB was added recently, but it fails when storing nested objects.  This seems to make it work for me.