### PR TITLE
Support overriding a Builder's default retryHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Options can also optionally take a hash with a key `dbClient` which points to an
 
 * `sslEnabled`: a boolean to turn ssl on or off for the connection.
 * `endPoint`: the address of the DynamoDB instance to try to communicate with.
-* `retryHandler`: a `function(method, table)` that will be triggered if Dynamite needs to retry a command.
+* `retryHandler`: a `function(method, table, response)` that will be triggered if Dynamite needs to retry a command.
 
 ### Foreword: Kew and You
 

--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -9,6 +9,7 @@ var DynamoResponse = require('./DynamoResponse')
  */
 function Builder(options) {
   this._options = options || {}
+  this._retryHandler = this._options.retryHandler
 }
 
 Builder.prototype.setHashKey = function (keyName, keyVal) {
@@ -28,7 +29,12 @@ Builder.prototype.setRangeKey = function (keyName, keyVal) {
 }
 
 Builder.prototype.getRetryHandler = function () {
-  return this._options.retryHandler
+  return this._retryHandler
+}
+
+Builder.prototype.setRetryHandler = function (retryHandler) {
+  this._retryHandler = retryHandler
+  return this
 }
 
 Builder.prototype.getOptions = function () {
@@ -137,8 +143,8 @@ Builder.prototype.request = function (method, data) {
     })
 
     if (retryHandler) {
-      req.on('retry', function () {
-        retryHandler(method, table)
+      req.on('retry', function (res) {
+        retryHandler(method, table, res)
       })
     }
   }

--- a/test/testQuery.js
+++ b/test/testQuery.js
@@ -346,7 +346,7 @@ builder.add(function testValidationError(test) {
     })
 })
 
-builder.add(function testDisableRetries(test) {
+builder.add(function testRetryHandler(test) {
   var client = this.client
   var calledRetryHandler = 0
 

--- a/test/testQuery.js
+++ b/test/testQuery.js
@@ -345,3 +345,22 @@ builder.add(function testValidationError(test) {
       test.equal('comments', e.table)
     })
 })
+
+builder.add(function testDisableRetries(test) {
+  var client = this.client
+  var calledRetryHandler = 0
+
+  return client.newQueryBuilder('comments')
+    .setHashKey('invalid', 'post1')
+    .setRetryHandler(function (method, table, response) {
+      test.equal(response.error.retryable, false)
+      ++calledRetryHandler
+    })
+    .execute()
+    .then(function () {
+      test.fail('Expected validation to fail!')
+    })
+    .fail(function () {
+      test.equal(calledRetryHandler, 1)
+    })
+})

--- a/test/utils/testUtils.js
+++ b/test/utils/testUtils.js
@@ -23,8 +23,8 @@ var options = {
   accessKeyId: 'xxx',
   secretAccessKey: 'xxx',
   region: 'xxx',
-  retryHandler: function (method, table) {
-    console.log('retrying', method, table)
+  retryHandler: function (method, table, response) {
+    console.log('retrying', method, table, response)
   }
 }
 


### PR DESCRIPTION
Hello @xiao, @nicks, 

Please review the following commits I made in branch 'kylewm/retry'.

3a7934d52b9d79a3c6ba600ca4bc092bf938d533 (2016-08-22 15:03:47 -0700)
Support overriding a Builder's default retryHandler
Also add  to the parameters we pass to the handler. Need
this to do any manipulation of the retry behavior (e.g., set response.error.retryable = false)

R=@xiao
R=@nicks