### PR TITLE
Track `requestId` in custome errors

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -192,11 +192,11 @@ Builder.prototype.convertErrors = function (context, err) {
 
   switch (err.code || err.name) {
     case 'ConditionalCheckFailedException':
-      throw new errors.ConditionalError(data, err.message)
+      throw new errors.ConditionalError(data, err.message, err.requestId)
     case 'ProvisionedThroughputExceededException':
-      throw new errors.ProvisioningError(data, err.message, isWrite)
+      throw new errors.ProvisioningError(data, err.message, isWrite, err.requestId)
     case 'ValidationException':
-      throw new errors.ValidationError(data, err.message, isWrite)
+      throw new errors.ValidationError(data, err.message, isWrite, err.requestId)
     default:
       throw err
   }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -5,15 +5,17 @@ var util = require('util')
 /**
  * @param {Object} data
  * @param {string} msg
+ * @param {string} requestId
  * @constructor
  * @extends {Error}
  */
-function ConditionalError(data, msg) {
+function ConditionalError(data, msg, requestId) {
   Error.captureStackTrace(this)
   this.data = data || {}
   this.message = 'The conditional request failed'
   this.details = msg
   this.table = data.TableName || 'unknown'
+  this.requestId = requestId
 }
 util.inherits(ConditionalError, Error)
 ConditionalError.prototype.type = 'ConditionalError'
@@ -24,16 +26,18 @@ ConditionalError.prototype.name = 'ConditionalError'
  * @param {Object} data
  * @param {string} msg
  * @param {boolean} isWrite
+ * @param {string} requestId
  * @constructor
  * @extends {Error}
  */
-function ProvisioningError(data, msg, isWrite) {
+function ProvisioningError(data, msg, isWrite, requestId) {
   Error.captureStackTrace(this)
   this.data = data || {}
   this.message = 'The level of configured provisioned throughput for the table was exceeded'
   this.details = msg
   this.table = data.TableName || 'unknown'
   this.isWrite = isWrite
+  this.requestId = requestId
 }
 util.inherits(ProvisioningError, Error)
 ProvisioningError.prototype.type = 'ProvisioningError'
@@ -44,15 +48,17 @@ ProvisioningError.prototype.name = 'ProvisioningError'
  * @param {Object} data
  * @param {string} msg
  * @param {boolean} isWrite
+ * @param {string} requestId
  * @constructor
  * @extends {Error}
  */
-function ValidationError(data, msg, isWrite) {
+function ValidationError(data, msg, isWrite, requestId) {
   Error.captureStackTrace(this)
   this.data = data || {}
   this.message = msg
   this.table = data.TableName || 'unknown'
   this.isWrite = isWrite
+  this.requestId = requestId
 }
 util.inherits(ValidationError, Error)
 ValidationError.prototype.type = 'ValidationError'

--- a/test/testPutItem.js
+++ b/test/testPutItem.js
@@ -212,3 +212,27 @@ builder.add(function testPutWithFailedAbsentConditionalExists(test) {
   })
   .fail(this.client.throwUnlessConditionalError)
 })
+
+// trigger a conditional error and check its content
+builder.add(function testConditionalErrorFormat(test) {
+  var conditions = this.client.newConditionBuilder()
+    .expectAttributeAbsent('age')
+
+  return this.client.putItem("user", {
+    userId: 'userA',
+    column: '@',
+    height: 72
+  })
+  .withCondition(conditions)
+  .execute()
+  .then(function () {
+    test.fail('This putItem request should fail due to a conditional error')
+  })
+  .fail(function (err) {
+    test.ok(err instanceof errors.ConditionalError)
+    test.equals('The conditional request failed', err.message, 'The "message" field should be the custom message')
+    test.equals('The conditional request failed', err.details, 'The "details" field should be the custom message')
+    test.equals('user', err.table, 'The "table" field should be the right table name')
+    test.ok(!!err.requestId, 'The "requestId" field should exist')
+  })
+})


### PR DESCRIPTION
Hello @kylewm, @kylehg, @nicks, 

Please review the following commits I made in branch 'xiao-track-requestId'.

8ce96fe6f0c6a30c011489cb3c9a35d25ada374d (2016-08-22 21:36:31 -0700)
Track `requestId` in custome errors

Request IDs are important information for triaging errors, especially
provisioning errors. They already exist in the raw Error objects
from AWS SDK. This change passes them to custom Error objects as well.

R=@kylewm
R=@kylehg
R=@nicks