### PR TITLE
Properly handle attribute names with underscores

### DIFF
--- a/lib/typeUtil.js
+++ b/lib/typeUtil.js
@@ -281,12 +281,39 @@ function clone(oldItem) {
   }
 }
 
+var VALID_ATTR_RE = /^[a-zA-Z][a-zA-Z0-9]*$/
+
 /**
  * @see http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ExpressionPlaceholders.html#ExpressionAttributeNames
  * @return {string} The alias. May just be the key itself if an alias is not needed.
  */
 function getAttributeAlias(key) {
-  return needsAttributeAlias(key) ? '#' + key : key
+  if (isReservedWord(key)) {
+    // If this is just a reserved word, use # + word
+    return '#' + key
+  }
+
+  if (!isAlphaNumeric(key)) {
+    // if this is not alphanumeric, hex-encode the string.
+    return '#' + new Buffer(key).toString('hex')
+  }
+
+  // otherwise, the key is valid in an expression
+  return key
+}
+
+/**
+ * @return {boolean} True if this is a reserved word.
+ */
+function isReservedWord(key) {
+  return (key.toUpperCase() in reserved.set)
+}
+
+/**
+ * @return {boolean} True if this matches the alphanumeric regexp
+ */
+function isAlphaNumeric(key) {
+  return VALID_ATTR_RE.test(key)
 }
 
 /**
@@ -294,7 +321,7 @@ function getAttributeAlias(key) {
  * @return {boolean} True if we need an attribute alias.
  */
 function needsAttributeAlias(key) {
-  return key.toUpperCase() in reserved.set
+  return isReservedWord(key) || !isAlphaNumeric(key)
 }
 
 /**

--- a/test/testTypeUtil.js
+++ b/test/testTypeUtil.js
@@ -65,3 +65,14 @@ builder.add(function testObjectIsNonEmptySet(test) {
 
   return Q.resolve()
 })
+
+builder.add(function testGetAttributeAlias(test) {
+  var getAlias = typeUtil.getAttributeAlias
+  test.equal('userId', getAlias('userId'))
+  test.equal('userId2', getAlias('userId2'))
+  test.equal('#comment', getAlias('comment')) // reserved word
+  test.equal('#5f5f757365724964', getAlias('__userId'))
+  test.equal('#7573657249645f', getAlias('userId_'))
+  test.equal('#30757365724964', getAlias('0userId'))
+  return Q.resolve()
+})

--- a/test/testUpdateItem.js
+++ b/test/testUpdateItem.js
@@ -413,3 +413,24 @@ builder.add(function testUpdateFailsWhenConditionalArgumentBad(test) {
   }
   test.done()
 })
+
+builder.add(function testPutAttributeWithUnderscores(test) {
+  var self = this
+
+  return this.client.newUpdateBuilder('user')
+    .setHashKey('userId', 'userA')
+    .setRangeKey('column', '@')
+    .enableUpsert()
+    .putAttribute('__age', 30)
+    .putAttribute('00height', 72)
+    .execute()
+    .then(function (data) {
+      test.equal(data.result.__age, 30, 'result __age should be 30')
+      test.equal(data.result['00height'], 72, 'result 00height should be 72')
+      return utils.getItemWithSDK(self.db, "userA", "@")
+    })
+    .then(function (data) {
+      test.equal(data['Item']['__age'].N, "30", "result age should be 30")
+      test.equal(data['Item']['00height'].N, "72", "height should be 72")
+    })
+})


### PR DESCRIPTION
Hello @kellyellis, @kylewm, 

Please review the following commits I made in branch 'nicks/attributename'.

ca5d2a0c660161cc22cc053ef5dac43f3ac11287 (2017-02-08 14:49:47 -0500)
Properly handle attribute names with underscores

R=@kellyellis
R=@kylewm