### PR TITLE
fix issue where FakeDynamo returns unsorted results when no range key condition is specified

### DIFF
--- a/lib/FakeDynamo.js
+++ b/lib/FakeDynamo.js
@@ -272,17 +272,11 @@ FakeTable.prototype._queryGlobalSecondaryIndex = function(data) {
   }
 
   // sort by the range key of the GSI (if there is any)
-  var sortByKey
-  forEachKeyCondition(data, function (condition, key) {
-    if (!sortByKey && condition.op != 'EQ') {
-      sortByKey = key
-    }
-  })
-  if (sortByKey) {
+  if (rangeKey) {
     results.sort(function (a, b) {
       return data.ScanIndexForward ?
-        a[sortByKey] - b[sortByKey] :
-        b[sortByKey] - a[sortByKey]
+        a[rangeKey] - b[rangeKey] :
+        b[rangeKey] - a[rangeKey]
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynamite",
   "description": "promise-based DynamoDB client",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "homepage": "https://github.com/Medium/dynamite",
   "license": "Apache-2.0",
   "authors": [

--- a/test/testFakeDynamo.js
+++ b/test/testFakeDynamo.js
@@ -447,8 +447,8 @@ builder.add(function testQueryOnGlobalSecondaryIndexes(test) {
 
   return client.newQueryBuilder('user')
     .setHashKey('age', 28)
-    // It is important that the index name has three or more terms (sepaprated by
-    // '-'), it's a DynamoDB index namng convention, and it is how we know that it
+    // It is important that the index name has three or more terms (separated by
+    // '-'), it's a DynamoDB index naming convention, and it is how we know that it
     // is a GSI query
     .setIndexName('age-height-gsi')
     .indexGreaterThan('height', 175)
@@ -496,8 +496,8 @@ builder.add(function testQueryOnGlobalSecondaryIndexWithoutCondition(test) {
 
   return client.newQueryBuilder('user')
     .setHashKey('userId', 'userA')
-    // It is important that the index name has three or more terms (sepaprated by
-    // '-'), it's a DynamoDB index namng convention, and it is how we know that it
+    // It is important that the index name has three or more terms (separated by
+    // '-'), it's a DynamoDB index naming convention, and it is how we know that it
     // is a GSI query
     .setIndexName('userId-height-gsi')
     .scanBackward()


### PR DESCRIPTION
Currently, when you use query.setIndexRangeKeyWithoutCondition, the results 
from FakeDynamo come back filtered properly but unsorted. This happens because
FakeDynamo makes a guess about which key is the range key based on the
KeyCondition -- whichever key in the KeyCondition does not have an EQ
relationship is the range key.  Of couse that heuristic doesn't work when there
is no condition on the range key.

With this change, instead of using the condition to guess what the range key
is, we just use the range key from the GSI definition directly.

<details>
<summary>REVIEWERS (6)</summary>

R=@adrianlee44
R=@eduardoramirez
R=@emily-cook
R=@ifefamojuro
R=@nickdmoore
R=@noelle100
</details>